### PR TITLE
新增 - 在读取MD文件时，添加对图片行和代码块的处理逻辑，设置状态为EXCLUDED

### DIFF
--- a/module/File/MD.py
+++ b/module/File/MD.py
@@ -6,6 +6,9 @@ from module.Cache.CacheItem import CacheItem
 
 class MD(Base):
 
+    # 添加图片匹配的正则表达式
+    IMAGE_PATTERN = re.compile(r'!\[.*?\]\(.*?\)')
+    
     def __init__(self, config: dict) -> None:
         super().__init__()
 
@@ -29,8 +32,6 @@ class MD(Base):
     # 读取
     def read_from_path(self, abs_paths: list[str]) -> list[CacheItem]:
         items = []
-        # 添加图片匹配的正则表达式
-        image_pattern = re.compile(r'!\[.*?\]\(.*?\)')
         
         for abs_path in set(abs_paths):
             # 获取相对路径
@@ -47,8 +48,7 @@ class MD(Base):
                         in_code_block = not in_code_block
                     
                     # 如果是图片行或在代码块内，设置状态为 EXCLUDED
-                    if (image_pattern.search(line) or 
-                        in_code_block):
+                    if (MD.IMAGE_PATTERN.search(line) or in_code_block):
                         items.append(
                             CacheItem({
                                 "src": line,

--- a/module/File/MD.py
+++ b/module/File/MD.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 from base.Base import Base
 from module.Cache.CacheItem import CacheItem
@@ -28,23 +29,48 @@ class MD(Base):
     # 读取
     def read_from_path(self, abs_paths: list[str]) -> list[CacheItem]:
         items = []
+        # 添加图片匹配的正则表达式
+        image_pattern = re.compile(r'!\[.*?\]\(.*?\)')
+        
         for abs_path in set(abs_paths):
             # 获取相对路径
             rel_path = os.path.relpath(abs_path, self.input_path)
 
             # 数据处理
             with open(abs_path, "r", encoding = "utf-8-sig") as reader:
-                for line in [line.removesuffix("\n") for line in reader.readlines()]:
-                    items.append(
-                        CacheItem({
-                            "src": line,
-                            "dst": line,
-                            "row": len(items),
-                            "file_type": CacheItem.FileType.MD,
-                            "file_path": rel_path,
-                            "text_type": CacheItem.TextType.MD,
-                        })
-                    )
+                lines = [line.removesuffix("\n") for line in reader.readlines()]
+                in_code_block = False  # 跟踪是否在代码块内
+                
+                for line in lines:
+                    # 检查是否进入或退出代码块
+                    if line.strip().startswith("```"):
+                        in_code_block = not in_code_block
+                    
+                    # 如果是图片行或在代码块内，设置状态为 EXCLUDED
+                    if (image_pattern.search(line) or 
+                        in_code_block):
+                        items.append(
+                            CacheItem({
+                                "src": line,
+                                "dst": line,
+                                "row": len(items),
+                                "file_type": CacheItem.FileType.MD,
+                                "file_path": rel_path,
+                                "text_type": CacheItem.TextType.MD,
+                                "status": Base.TranslationStatus.EXCLUDED,
+                            })
+                        )
+                    else:
+                        items.append(
+                            CacheItem({
+                                "src": line,
+                                "dst": line,
+                                "row": len(items),
+                                "file_type": CacheItem.FileType.MD,
+                                "file_path": rel_path,
+                                "text_type": CacheItem.TextType.MD,
+                            })
+                        )
 
         return items
 


### PR DESCRIPTION
## 修改内容
在处理Markdown文件时，为了保持翻译的质量和避免不必要的错误，本次PR添加了以下功能：

1. 添加了图片匹配的正则表达式，用于识别Markdown中的图片行
2. 添加了对代码块的识别逻辑，使用一个布尔变量跟踪是否在代码块内
3. 对于识别到的图片行或代码块内的内容，设置其状态为EXCLUDED，避免在翻译过程中被处理

## 修改原因
Markdown文件中的图片引用行和代码块通常不需要翻译，或者翻译后可能会导致格式错误。例如：
- 图片引用行如 `![图片描述](图片路径)` 翻译后可能会破坏图片显示
- 代码块内的内容通常是编程代码，不需要进行翻译

通过将这些内容标记为EXCLUDED，可以在翻译过程中自动跳过这些部分，提高翻译质量和效率。

## 影响范围
此修改仅影响Markdown文件的处理逻辑，不会影响其他文件类型的翻译流程。

## 测试情况
已测试包含图片引用和代码块的Markdown文件，确认这些内容被正确标记为EXCLUDED状态，不会被翻译。
