### PR TITLE
新增-文件格式支持-ParaTranz json

### DIFF
--- a/module/Cache/CacheItem.py
+++ b/module/Cache/CacheItem.py
@@ -34,6 +34,7 @@ class CacheItem():
         TRANS = "TRANS"                            # .trans Translator++
         KVJSON = "KVJSON"                          # .json MTool
         MESSAGEJSON = "MESSAGEJSON"                # .json SExtractor
+        PARATRANZJSON = "PARATRANZJSON"            # .json ParaTranz
 
     class TextType(StrEnum):
 
@@ -47,6 +48,7 @@ class CacheItem():
     # 默认值
     src: str = ""                                                                               # 原文
     dst: str = ""                                                                               # 译文
+    pzkey: str = ""                                                                             # ParaTranz key
     name_src: str | list[str] = None                                                            # 角色姓名原文
     name_dst: str | list[str] = None                                                            # 角色姓名译文
     extra_field: str | dict = ""                                                                # 额外字段原文
@@ -109,6 +111,16 @@ class CacheItem():
     def set_src(self, src: str) -> None:
         with self.lock:
             self.src = src
+
+    # 获取pzkey
+    def get_pzkey(self) -> str:
+        with self.lock:
+            return self.pzkey
+
+    # 设置pzkey
+    def set_pzkey(self, pzkey: str) -> None:
+        with self.lock:
+            self.pzkey = pzkey
 
     # 获取译文
     def get_dst(self) -> str:

--- a/module/File/FileManager.py
+++ b/module/File/FileManager.py
@@ -11,6 +11,7 @@ from module.File.EPUB import EPUB
 from module.File.KVJSON import KVJSON
 from module.File.MD import MD
 from module.File.MESSAGEJSON import MESSAGEJSON
+from module.File.PARATRANZJSON import PARATRANZJSON
 from module.File.RENPY import RENPY
 from module.File.SRT import SRT
 from module.File.TRANS.TRANS import TRANS
@@ -54,6 +55,7 @@ class FileManager(Base):
             items.extend(TRANS(self.config).read_from_path([path for path in paths if path.lower().endswith(".trans")]))
             items.extend(KVJSON(self.config).read_from_path([path for path in paths if path.lower().endswith(".json")]))
             items.extend(MESSAGEJSON(self.config).read_from_path([path for path in paths if path.lower().endswith(".json")]))
+            items.extend(PARATRANZJSON(self.config).read_from_path([path for path in paths if path.lower().endswith(".json")]))
         except Exception as e:
             self.error(f"{Localizer.get().log_read_file_fail}", e)
 
@@ -73,5 +75,6 @@ class FileManager(Base):
             TRANS(self.config).write_to_path(items)
             KVJSON(self.config).write_to_path(items)
             MESSAGEJSON(self.config).write_to_path(items)
+            PARATRANZJSON(self.config).write_to_path(items)
         except Exception as e:
             self.error(f"{Localizer.get().log_write_file_fail}", e)

--- a/module/File/PARATRANZJSON.py
+++ b/module/File/PARATRANZJSON.py
@@ -1,0 +1,118 @@
+import os
+import json
+
+from base.Base import Base
+from base.BaseLanguage import BaseLanguage
+from module.Text.TextHelper import TextHelper
+from module.Cache.CacheItem import CacheItem
+from module.Config import Config
+
+class PARATRANZJSON(Base):
+
+    # [
+    #   {
+    #     "key": "KEY 键值",
+    #     "original": "source text 原文",
+    #     "translation": "translation text 译文"
+    #   }
+    # ]
+
+    def __init__(self, config: Config) -> None:
+        super().__init__()
+
+        # 初始化
+        self.config = config
+        self.input_path: str = config.input_folder
+        self.output_path: str = config.output_folder
+        self.source_language: BaseLanguage.Enum = config.source_language
+        self.target_language: BaseLanguage.Enum = config.target_language
+
+    # 读取
+    def read_from_path(self, abs_paths: list[str]) -> list[CacheItem]:
+        items:list[CacheItem] = []
+        for abs_path in abs_paths:
+            # 获取相对路径
+            rel_path = os.path.relpath(abs_path, self.input_path)
+
+            # 获取文件编码
+            encoding = TextHelper.get_enconding(path = abs_path, add_sig_to_utf8 = True)
+
+            # 数据处理
+            with open(abs_path, "r", encoding = encoding) as reader:
+                json_data: list[dict] = json.load(reader)
+
+                # 格式校验
+                if not isinstance(json_data, list):
+                    continue
+
+                # 读取数据
+                for entry in json_data:
+                    if not isinstance(entry, dict):
+                        continue
+                    
+                    key = entry.get("key")
+                    original = entry.get("original")
+                    translation = entry.get("translation")
+
+                    if isinstance(key, str) and isinstance(original, str) and isinstance(translation, str):
+                        src = original
+                        dst = translation
+                        pzkey = key
+                        
+
+                        if src == "":
+                            status = Base.TranslationStatus.EXCLUDED
+                        elif dst != "" and src != dst:
+                            status = Base.TranslationStatus.TRANSLATED_IN_PAST
+                        else:
+                            status = Base.TranslationStatus.UNTRANSLATED
+                        
+                        items.append(
+                            CacheItem.from_dict({
+                                "pzkey": pzkey,
+                                "src": src,
+                                "dst": dst,
+                                "row": len(items),
+                                "file_type": CacheItem.FileType.PARATRANZJSON,
+                                "file_path": rel_path,
+                                "status": status,
+                               
+                            })
+                        )
+
+        return items
+
+    # 写入
+    def write_to_path(self, items: list[CacheItem]) -> None:
+        target = [
+            item for item in items
+            if item.get_file_type() == CacheItem.FileType.PARATRANZJSON
+        ]
+
+        group: dict[str, list[CacheItem]] = {}
+        for item in target:
+            group.setdefault(item.get_file_path(), []).append(item)
+
+        for rel_path, file_items in group.items():
+            # 按行号排序
+            file_items = sorted(file_items, key = lambda x: x.get_row())
+            
+            abs_path = os.path.join(self.output_path, rel_path)
+            os.makedirs(os.path.dirname(abs_path), exist_ok = True)
+            
+            result_data = []
+            for item in file_items:              
+                result_data.append({
+                    "key": item.get_pzkey(),
+                    "original": item.get_src(),
+                    "translation": item.get_dst()
+                })
+
+            with open(abs_path, "w", encoding = "utf-8") as writer:
+                writer.write(
+                    json.dumps(
+                        result_data,
+                        indent = 2,
+                        ensure_ascii = False,
+                    )
+                )

--- a/module/File/PARATRANZJSON.py
+++ b/module/File/PARATRANZJSON.py
@@ -9,11 +9,18 @@ from module.Config import Config
 
 class PARATRANZJSON(Base):
 
+    # key格式不固定但是不需要翻译，original为原文，translation为译文，stage是从paratranz下载字典时自动添加的翻译状态标识符，本地不需要管
     # [
     #   {
-    #     "key": "KEY 键值",
-    #     "original": "source text 原文",
-    #     "translation": "translation text 译文"
+    #     "key": "1_2",
+    #     "original": "主人公の宿が存在する場所。交通の要所であり、交易都市として栄えているゼカリウスには東西南北から様々な品が流れてくる。アーマニアの海の幸や、肥沃な農牧地帯の産物により、住民の幸福度は高い。",
+    #     "translation": "主角的旅馆所在之处，交通要冲，以贸易都市繁荣著称的泽卡利乌斯从东西南北各方引进了各种各样的商品。阿玛尼亚海的海产与肥沃农牧地带的产物提高了居民的生活质量。"
+    #   }，
+    #   {
+    #     "key": "1_3",
+    #     "original": "水上都市ゼカリウス",
+    #     "translation": "",
+    #     "stage": 0
     #   }
     # ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # System
 PyQt-Fluent-Widgets[full]
-openai
+openai >=1.100.2
 anthropic
 google-genai
 tiktoken


### PR DESCRIPTION
### 修改内容
本PR为程序新增了对ParaTranz json格式的支持

### 修改原因
[ParaTranz](https://paratranz.cn/projects)是目前国内进行汉化项目协作时常用的翻译平台。在将其不支持自动解析的文本格式上传时会用到该通用json结构。为了便于通过AI进行批量汉化及后续的协作润色/校对操作，故创建此PR

### 修改范围
本PR修改范围仅限于/module/File中添加PARATRANZJSON.py,以及对/module/File/FileManager.py及/module/Cache/CacheItem.py进行必要的修改以添加文件格式入点。

### 测试情况
已使用本人当前正在进行的项目所提取的文件进行翻译测试，程序运行正常，输出符合预期
<img width="1922" height="498" alt="image" src="https://github.com/user-attachments/assets/40e00b1d-a1d6-4936-a8ed-9d42921f9be3" />
<img width="1895" height="493" alt="image" src="https://github.com/user-attachments/assets/ef76f0d3-adac-4f3d-8d45-8f1035ff3f0c" />
