### PR TITLE
Extend API parameter sliders to support values up to 2.0

### DIFF
--- a/frontend/Project/ArgsEditPage.py
+++ b/frontend/Project/ArgsEditPage.py
@@ -101,7 +101,7 @@ class ArgsEditPage(MessageBoxBase, Base):
             switch_button.setOffText("")
             widget.add_widget(switch_button)
 
-            widget.get_slider().setRange(0, 200)
+            widget.get_slider().setRange(0, 100)
             widget.get_slider().setValue(int(self.platform.get("top_p") * 100))
             widget.get_value_label().setText(f"{self.platform.get("top_p"):.2f}")
 
@@ -159,7 +159,7 @@ class ArgsEditPage(MessageBoxBase, Base):
             switch_button.setOffText("")
             widget.add_widget(switch_button)
 
-            widget.get_slider().setRange(0, 200)
+            widget.get_slider().setRange(0, 100)
             widget.get_slider().setValue(int(self.platform.get("presence_penalty") * 100))
             widget.get_value_label().setText(f"{self.platform.get("presence_penalty"):.2f}")
 
@@ -188,7 +188,7 @@ class ArgsEditPage(MessageBoxBase, Base):
             switch_button.setOffText("")
             widget.add_widget(switch_button)
 
-            widget.get_slider().setRange(0, 200)
+            widget.get_slider().setRange(0, 100)
             widget.get_slider().setValue(int(self.platform.get("frequency_penalty") * 100))
             widget.get_value_label().setText(f"{self.platform.get("frequency_penalty"):.2f}")
 


### PR DESCRIPTION
Extended the range for temperature, top_p, presence_penalty and
  frequency_penalty sliders from 0-100 to 0-200, allowing values up to 2.0.

  This change enables users to configure higher temperatures for improved
  translation quality. DeepSeek specifically recommends a temperature of 1.3
  for translation tasks, which was not possible with the previous 0-1.0 limit.

  Benefits:
  - DeepSeek: 1.3 for translations (recommended)
  - Other models can now use values up to 2.0 as needed
  - More flexibility for different use cases