### PR TITLE
修复 - tiktoken 编码含特殊 token 字符串时抛出 ValueError

### DIFF
--- a/model/Item.py
+++ b/model/Item.py
@@ -23,7 +23,8 @@ TOKEN_ENCODING = tiktoken.get_encoding(TOKEN_ENCODING_NAME)
 
 @lru_cache(maxsize=TOKEN_COUNT_CACHE_MAXSIZE)
 def get_token_count_from_text(text: str) -> int:
-    return len(TOKEN_ENCODING.encode(text))
+    # disallowed_special=() 避免文本中包含形如 <|endoftext|> 的字符串时抛出异常
+    return len(TOKEN_ENCODING.encode(text, disallowed_special=()))
 
 
 @dataclasses.dataclass
@@ -305,7 +306,7 @@ class Item:
 
         # 长文本跳过全局缓存，避免内存膨胀
         if len(src) > TOKEN_COUNT_CACHE_TEXT_LIMIT:
-            token_count = len(TOKEN_ENCODING.encode(src))
+            token_count = len(TOKEN_ENCODING.encode(src, disallowed_special=()))
         else:
             token_count = get_token_count_from_text(src)
 


### PR DESCRIPTION
## Summary
- 翻译电子书时，正文中可能包含形如 `<|endoftext|>` 的字符串
- tiktoken 默认将其视为特殊 token 并拒绝编码，导致 `ValueError` 异常使翻译任务失败
- 在 `model/Item.py` 的两处 `TOKEN_ENCODING.encode()` 调用中传入 `disallowed_special=()`，将特殊 token 作为普通文本处理
  - `get_token_count_from_text()` — 短文本路径（经 lru_cache 缓存）
  - `Item.get_token_count()` — 长文本路径（跳过全局缓存）

## Test plan
- [ ] 使用包含 `<|endoftext|>` 字符串的 epub 文件进行翻译测试，确认不再抛出异常
- [ ] 验证正常文本的 token 计数结果不受影响

🤖 Generated with [Claude Code](https://claude.ai/claude-code)