### PR TITLE
修复：EPUB 首字下沉导致首字母泄漏到译文

### DIFF
--- a/module/File/EPUB/EPUBAst.py
+++ b/module/File/EPUB/EPUBAst.py
@@ -604,6 +604,45 @@ class EPUBAst(Base):
             cur = cur.getparent()
         return False
 
+    @staticmethod
+    def merge_drop_cap_slots(
+        part_defs: list[dict[str, str]],
+        part_texts: list[str],
+    ) -> tuple[list[dict[str, str]], list[str]]:
+        """合并首字下沉槽位：当某个槽归一化后只有单个字母，且下一个槽以小写字母开头时，
+        说明它们原本属于同一个单词（EPUB 的 drop cap 样式导致拆分）。
+        合并后原单字母槽标记为空占位（"drop_cap_merged"），写回时该槽置空。
+        """
+        if len(part_defs) < 2:
+            return part_defs, part_texts
+
+        merged_defs: list[dict[str, str]] = []
+        merged_texts: list[str] = []
+        i = 0
+        while i < len(part_texts):
+            text = part_texts[i].strip()
+            # 检测：当前槽为单个字母，且下一个槽以小写字母开头
+            if (
+                i + 1 < len(part_texts)
+                and len(text) == 1
+                and text.isalpha()
+                and part_texts[i + 1].strip()
+                and part_texts[i + 1].strip()[0].islower()
+            ):
+                # 原单字母槽标记为空占位，写回时置空
+                merged_defs.append({**part_defs[i], "drop_cap_merged": "true"})
+                merged_texts.append("")
+                # 下一个槽吸收首字母
+                merged_defs.append(part_defs[i + 1])
+                merged_texts.append(text + part_texts[i + 1])
+                i += 2
+            else:
+                merged_defs.append(part_defs[i])
+                merged_texts.append(part_texts[i])
+                i += 1
+
+        return merged_defs, merged_texts
+
     def create_item_from_slots(
         self,
         doc_path: str,
@@ -627,8 +666,13 @@ class EPUBAst(Base):
         if not has_non_empty_text:
             return None
 
-        src = "\n".join(part_texts)
+        # digest 必须使用合并前的原始文本，以便写回时树中原始文本能匹配
         digest = self.sha1_hex_with_null_separator(part_texts)
+
+        # 合并首字下沉：单字母槽 + 小写开头的后续槽 → 合并为完整单词
+        part_defs, part_texts = self.merge_drop_cap_slots(part_defs, part_texts)
+
+        src = "\n".join(part_texts)
         return Item.from_dict(
             {
                 "src": src,


### PR DESCRIPTION
## 问题描述
现在翻译英语书（可能别的语言也有类似问题），书的每章第一个字母往往会大写，然后翻译出现问题。
比如“The Magi are an ancient and mysterious……”被翻译成“T贤者们是个古老又神秘的”，

“Past midnight, and it was dark in the Middleway.”
被翻成“P过了午夜，米德尔路上一片漆黑”。不是所有章节都有这个问题，但是不少章节都存在把首大写字母误带到译文的情况。


## 以下是claude 的原因分析
EPUB 电子书中常用 `<span>` 标签包裹章节首字母来实现首字下沉（Drop Cap）效果。这导致首字母被提取为独立的文本槽位，例如 `"T"` + `"he Magi are..."`。

LLM 翻译时会将单字母原样保留，其余部分翻译为中文，最终拼出错误的结果：
- `"The Magi are an ancient..."` → `"T贤者们是个古老又神秘的..."`
- `"Past midnight..."` → `"P过了午夜..."`

## 修复方案

在 `EPUBAst.create_item_from_slots()` 中新增 `merge_drop_cap_slots()` 方法：
- 检测当前槽位为单个字母且下一个槽位以小写字母开头的模式（说明原本是同一个单词被拆分）
- 自动合并为完整单词，使 LLM 看到 `"The Magi are..."` 而非 `"T"` + `"he Magi are..."`
- 写回时原单字母槽位置空，译文整体写入合并后的槽位

## 测试

- [x] 全部现有 EPUB 测试通过（113 passed）
- [ ] 使用含首字下沉样式的 EPUB 进行翻译，验证首字母不再泄漏到译文中