### PR TITLE
fix(engine): fast-fail permanent request errors, add retry backoff

### DIFF
--- a/src/backend/engine/core/engine-options.ts
+++ b/src/backend/engine/core/engine-options.ts
@@ -26,6 +26,7 @@ export interface TaskEngineOptions {
   taskPlanner: TaskPlanner; // 精确 token 切块、cache 复用和后台规划的唯一入口
   AppSettingService: AppSettingService; // 在每次任务启动时提供设置与模型快照
   logManager: LogManager; // 统一收敛任务引擎和 worker 回放日志
+  retryBackoffMs?: (retryCount: number) => number; // 重试前的退避时长；测试注入恒为 0 以保持快速
 }
 
 /**

--- a/src/backend/engine/core/engine.test.ts
+++ b/src/backend/engine/core/engine.test.ts
@@ -61,6 +61,7 @@ describe("TaskEngine", () => {
       taskPlanner: create_test_task_planner(),
       AppSettingService: create_setting_service(),
       logManager: create_log_manager(),
+      retryBackoffMs: () => 0,
     });
 
     await task_engine.start({
@@ -210,6 +211,7 @@ describe("TaskEngine", () => {
       taskPlanner: create_test_task_planner(),
       AppSettingService: create_setting_service(2),
       logManager: create_log_manager(),
+      retryBackoffMs: () => 0,
     });
 
     await task_engine.start({

--- a/src/backend/engine/core/engine.ts
+++ b/src/backend/engine/core/engine.ts
@@ -41,6 +41,13 @@ const TRANSLATION_TERMINAL_STATUSES = new Set(["PROCESSED", "ERROR"]); // 翻译
 const TRANSLATION_RETRY_LIMIT = 3; // 翻译重试次数高于分析，因为翻译支持拆分重试，分析只按 chunk 重试
 const ANALYSIS_RETRY_LIMIT = 2; // 分析失败只重发同一 chunk，过多重试会阻塞后续文件 checkpoint
 
+// 重试前固定退避，避免鉴权失效等持续性故障下同一 chunk 被立即重新打满请求
+const DEFAULT_RETRY_BACKOFF_STEP_MS = 500;
+const DEFAULT_RETRY_BACKOFF_MAX_MS = 2000;
+function default_retry_backoff_ms(retry_count: number): number {
+  return Math.min(DEFAULT_RETRY_BACKOFF_STEP_MS * retry_count, DEFAULT_RETRY_BACKOFF_MAX_MS);
+}
+
 const DEFAULT_INPUT_TOKEN_LIMIT = 512; // 模型未配置 token 限制时使用保守默认值，避免一次塞入过长 prompt
 // 一次任务启动时冻结配置和模型，运行中不跟随设置页热变更
 interface TaskRunContext {
@@ -63,6 +70,7 @@ export class TaskEngine {
   private readonly log_replay: TaskLogReplay; // 统一处理任务生命周期日志和 worker 日志回放
   private readonly limiter_pool = new LimiterPool(); // 后台任务按模型资源键复用请求节奏入口
   private readonly model_key_lease_pool = new ModelKeyLeasePool(); // 在主线程维护任务级全局 Key 轮换
+  private readonly retry_backoff_ms: (retryCount: number) => number; // 重试退避时长计算，测试可注入恒 0
   private request_in_flight_count = 0; // 只表达实时网络压力，不落库也不参与恢复
 
   /**
@@ -78,6 +86,7 @@ export class TaskEngine {
     this.app_setting_service = options.AppSettingService;
     this.run_coordinator = new RunCoordinator(options.taskRunPublisher);
     this.log_replay = new TaskLogReplay(options.logManager);
+    this.retry_backoff_ms = options.retryBackoffMs ?? default_retry_backoff_ms;
   }
 
   /**
@@ -261,6 +270,7 @@ export class TaskEngine {
     limiter: TaskLimiter,
     signal: AbortSignal,
   ) {
+    await this.wait_before_retry(context.retry_count, signal);
     const result = await this.call_translation_executor_with_retryable_transport(
       context,
       handle,
@@ -308,6 +318,7 @@ export class TaskEngine {
     limiter: TaskLimiter,
     signal: AbortSignal,
   ) {
+    await this.wait_before_retry(context.retry_count, signal);
     const result = await this.call_with_limiter(handle, limiter, signal, () =>
       this.executor_client
         .execute_unit(
@@ -360,6 +371,27 @@ export class TaskEngine {
         stopped: false,
       };
     }
+  }
+
+  /**
+   * 重试前固定退避；首次尝试（retry_count 为 0）不等待，停止信号触发时立即放弃等待
+   */
+  private async wait_before_retry(retry_count: number, signal: AbortSignal): Promise<void> {
+    const delay_ms = retry_count > 0 ? this.retry_backoff_ms(retry_count) : 0;
+    if (delay_ms <= 0 || signal.aborted) {
+      return;
+    }
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, delay_ms);
+      signal.addEventListener(
+        "abort",
+        () => {
+          clearTimeout(timer);
+          resolve();
+        },
+        { once: true },
+      );
+    });
   }
 
   /**

--- a/src/backend/engine/work-unit/runners/translation-runner.test.ts
+++ b/src/backend/engine/work-unit/runners/translation-runner.test.ts
@@ -148,6 +148,52 @@ describe("TranslationWorkUnitRunner", () => {
     expect(String(result.logs[0]?.message ?? "")).not.toContain("行数不一致");
   });
 
+  it("永久性请求错误直接标记条目为 ERROR，不再等待重试", async () => {
+    const runner = new TranslationWorkUnitRunner(
+      await create_template_root(),
+      create_llm_client({
+        request_error: { name: "ApiError", message: "API key not valid" },
+        request_error_retryable: false,
+      }),
+    );
+
+    const result = await runner.execute_unit(
+      create_translation_unit({
+        model: { api_format: "OpenAI" },
+        src: "こんにちは",
+      }),
+      new AbortController().signal,
+    );
+
+    expect(result.outcome).toBe("failed");
+    const items = result.output.kind === "translation" ? result.output.items : [];
+    expect(items).toMatchObject([{ status: "ERROR" }]);
+    expect(String(result.logs[0]?.message ?? "")).toContain("鉴权或参数错误");
+  });
+
+  it("临时性请求错误保留 NONE 状态，交给 Engine 重试", async () => {
+    const runner = new TranslationWorkUnitRunner(
+      await create_template_root(),
+      create_llm_client({
+        request_error: { name: "ApiError", message: "rate limited" },
+        request_error_retryable: true,
+      }),
+    );
+
+    const result = await runner.execute_unit(
+      create_translation_unit({
+        model: { api_format: "OpenAI" },
+        src: "こんにちは",
+      }),
+      new AbortController().signal,
+    );
+
+    expect(result.outcome).toBe("failed");
+    const items = result.output.kind === "translation" ? result.output.items : [];
+    expect(items).toMatchObject([{ status: "NONE" }]);
+    expect(String(result.logs[0]?.message ?? "")).toContain("将自动重试");
+  });
+
   it("部分合法译文无法覆盖请求行时记录行数不一致", async () => {
     const runner = new TranslationWorkUnitRunner(
       await create_template_root(),

--- a/src/backend/engine/work-unit/runners/translation-runner.ts
+++ b/src/backend/engine/work-unit/runners/translation-runner.ts
@@ -216,6 +216,7 @@ export class TranslationWorkUnitRunner {
         items,
         stream_degraded: response.degraded,
         request_error: response.request_error,
+        request_error_retryable: response.request_error_retryable ?? true,
         request_timeout: response.timeout,
       },
       response,
@@ -308,6 +309,7 @@ export class TranslationWorkUnitRunner {
       items: TextTaskItemRecord[];
       stream_degraded: boolean;
       request_error?: LogError;
+      request_error_retryable: boolean;
       request_timeout: boolean;
     },
     response: LLMRequestResult,
@@ -345,6 +347,19 @@ export class TranslationWorkUnitRunner {
       request_error: context.request_error,
       request: context.request,
     });
+    if (context.request_error !== undefined && !context.request_error_retryable) {
+      for (const item of context.items) {
+        item.status = "ERROR";
+      }
+      return {
+        items: context.items,
+        row_count: 0,
+        input_tokens: response.input_tokens,
+        output_tokens: response.output_tokens,
+        stopped: false,
+        logs,
+      };
+    }
     let updated_count = 0;
     if (decision.used_fallback && decision.fallback_dst !== null) {
       const item = context.items[0];
@@ -467,6 +482,7 @@ export class TranslationWorkUnitRunner {
       items: TextTaskItemRecord[];
       stream_degraded: boolean;
       request_error?: LogError;
+      request_error_retryable?: boolean;
       request_timeout: boolean;
     },
     alignment: TranslationAlignment,
@@ -555,11 +571,15 @@ export class TranslationWorkUnitRunner {
       items: TextTaskItemRecord[];
       stream_degraded: boolean;
       request_error?: LogError;
+      request_error_retryable?: boolean;
       request_timeout: boolean;
     },
     alignment: TranslationAlignment,
   ): string[] {
     const srcs = read_translation_text_srcs(context.lines);
+    if (context.request_error !== undefined && context.request_error_retryable === false) {
+      return srcs.map(() => "FAIL_REQUEST_PERMANENT");
+    }
     if (context.request_error !== undefined) {
       return srcs.map(() => "FAIL_REQUEST");
     }
@@ -726,6 +746,9 @@ export class TranslationWorkUnitRunner {
         }),
       };
     }
+    if (checks.every((check) => check === "FAIL_REQUEST_PERMANENT")) {
+      return { level: "error", message: this.t(app_language, "app.log.request_failed_permanent") };
+    }
     if (checks.every((check) => check === "FAIL_REQUEST")) {
       return { level: "error", message: this.t(app_language, "app.log.request_failed_retry") };
     }
@@ -763,6 +786,8 @@ export class TranslationWorkUnitRunner {
       case "FAIL_DEGRADATION":
         return this.t(app_language, "app.log.response_checker_fail_degradation");
       case "FAIL_REQUEST":
+        return this.t(app_language, "app.log.response_checker_fail_request");
+      case "FAIL_REQUEST_PERMANENT":
         return this.t(app_language, "app.log.response_checker_fail_request");
       default:
         return check;

--- a/src/backend/llm/llm-client.test.ts
+++ b/src/backend/llm/llm-client.test.ts
@@ -70,6 +70,57 @@ describe("LLMClient", () => {
     expect(result.request_error?.stack).toContain("供应商爆炸");
   });
 
+  it("鉴权类永久性错误标记为不可重试", async () => {
+    const client = new LLMClient({
+      userAgent: TEST_USER_AGENT,
+      transports: {
+        "openai-compatible": {
+          send: async () => {
+            throw Object.assign(new Error("API key not valid"), { status: 401 });
+          },
+        },
+      },
+    });
+
+    const result = await client.request(create_body(), new AbortController().signal);
+
+    expect(result.request_error_retryable).toBe(false);
+  });
+
+  it("限流类临时性错误仍标记为可重试", async () => {
+    const client = new LLMClient({
+      userAgent: TEST_USER_AGENT,
+      transports: {
+        "openai-compatible": {
+          send: async () => {
+            throw Object.assign(new Error("rate limited"), { status: 429 });
+          },
+        },
+      },
+    });
+
+    const result = await client.request(create_body(), new AbortController().signal);
+
+    expect(result.request_error_retryable).toBe(true);
+  });
+
+  it("错误没有携带状态码时保守按可重试处理", async () => {
+    const client = new LLMClient({
+      userAgent: TEST_USER_AGENT,
+      transports: {
+        "openai-compatible": {
+          send: async () => {
+            throw new Error("网络中断");
+          },
+        },
+      },
+    });
+
+    const result = await client.request(create_body(), new AbortController().signal);
+
+    expect(result.request_error_retryable).toBe(true);
+  });
+
   it("外部取消请求时返回 cancelled 结果", async () => {
     const controller = new AbortController();
     const client = new LLMClient({

--- a/src/backend/llm/llm-client.ts
+++ b/src/backend/llm/llm-client.ts
@@ -18,6 +18,28 @@ import type {
   RequestTransport,
 } from "./transport/transport-types";
 
+// 官方 SDK（Google/OpenAI/Anthropic）的 APIError 都在 error.status 上暴露真实 HTTP 状态码
+const NON_RETRYABLE_HTTP_STATUS_CODES = new Set([400, 401, 403, 404, 422]); // 请求参数、鉴权类错误重试没有意义，直接终结避免浪费重试预算
+
+/**
+ * 从 SDK 抛出的原始错误里读取 HTTP 状态码；取不到时保守按可重试处理
+ */
+function read_error_http_status(error: unknown): number | null {
+  if (typeof error !== "object" || error === null) {
+    return null;
+  }
+  const status = (error as { status?: unknown }).status;
+  return typeof status === "number" ? status : null;
+}
+
+/**
+ * 鉴权、参数类永久性错误重试没有意义；状态码缺失（网络错误、超时）时按可重试处理
+ */
+function is_retryable_llm_error(error: unknown): boolean {
+  const status = read_error_http_status(error);
+  return status === null || !NON_RETRYABLE_HTTP_STATUS_CODES.has(status);
+}
+
 interface LLMClientOptions {
   userAgent: string; // 由应用元信息层注入，LLMClient 不读取 version.txt
   policy?: LLMClientPolicy; // 注入点只供测试替换请求策略，不改变生产归属
@@ -88,6 +110,7 @@ export class LLMClient implements LLMClientPort {
           run_id: body.run_id,
           work_unit_id: body.work_unit_id,
         }),
+        request_error_retryable: is_retryable_llm_error(error),
       });
     } finally {
       clearTimeout(timer);

--- a/src/backend/llm/llm-types.ts
+++ b/src/backend/llm/llm-types.ts
@@ -33,6 +33,7 @@ export interface LLMRequestResult {
   timeout: boolean;
   degraded: boolean;
   request_error?: LogError; // 保留供应商或传输异常错误，缺失表示没有请求级失败
+  request_error_retryable?: boolean; // 仅在 request_error 存在时有意义；401/400 等永久性错误为 false，缺失按可重试处理
 }
 
 /**

--- a/src/shared/i18n/resources/de-DE/app.ts
+++ b/src/shared/i18n/resources/de-DE/app.ts
@@ -333,6 +333,8 @@ export const de_de_app = {
     response_checker_fail_line_count: "Zeilenanzahl stimmt nicht überein",
     response_checker_fail_request: "Modellanfrage fehlgeschlagen",
     request_failed_retry: "Modellanfrage fehlgeschlagen, wird automatisch wiederholt …",
+    request_failed_permanent:
+      "Modellanfrage fehlgeschlagen (Authentifizierungs- oder Parameterfehler, Wiederholung sinnlos), dieser Eintrag wurde abgebrochen …",
     response_checker_fail_timeout: "Netzwerkanfrage-Zeitüberschreitung",
     response_checker_line_error_empty_line: "Leere Zeile",
     system_closed_dropped:

--- a/src/shared/i18n/resources/en-US/app.ts
+++ b/src/shared/i18n/resources/en-US/app.ts
@@ -320,6 +320,8 @@ export const en_us_app = {
     response_checker_fail_line_count: "Line Count Mismatch",
     response_checker_fail_request: "Model Request Failed",
     request_failed_retry: "Model request failed, will automatically retry …",
+    request_failed_permanent:
+      "Model request failed (auth or parameter error, retrying is pointless), this item has been terminated …",
     response_checker_fail_timeout: "Network Request Timeout",
     response_checker_line_error_empty_line: "Empty Line",
     system_closed_dropped: "Log system is shut down; dropping new log: {MESSAGE}",

--- a/src/shared/i18n/resources/zh-CN/app.ts
+++ b/src/shared/i18n/resources/zh-CN/app.ts
@@ -314,6 +314,7 @@ export const zh_cn_app = {
     response_checker_fail_line_count: "行数不一致",
     response_checker_fail_request: "模型请求失败",
     request_failed_retry: "模型请求失败，将自动重试 …",
+    request_failed_permanent: "模型请求失败（鉴权或参数错误，重试无意义），已终止当前条目 …",
     response_checker_fail_timeout: "网络请求超时",
     response_checker_line_error_empty_line: "存在空行",
     system_closed_dropped: "日志系统已关闭，丢弃新日志：{MESSAGE}",


### PR DESCRIPTION
## Summary
- When a translation request fails, the engine previously retried a fixed 3 times regardless of the failure reason, and re-dispatched retries immediately with no delay. A permanent client error (e.g. an invalid API key returning HTTP 401/400) would get retried exactly like a transient one, wasting the full retry budget across every in-flight work unit before finally giving up.
- `LLMClient` now reads the HTTP status code exposed by the official Google/OpenAI/Anthropic SDK error objects (`error.status`) and classifies 400/401/403/404/422 as non-retryable. When such an error occurs, the affected item(s) are marked `ERROR` immediately instead of being requeued, so a bad API key (or similar permanent misconfiguration) fails fast instead of burning through hundreds of doomed requests.
- Retries that are still legitimate (429, 5xx, network errors, or any error without a recognizable status) now wait a small fixed backoff (500ms, capped at 2s) before being re-dispatched, instead of hammering the same failing endpoint back-to-back with zero delay.
- Scope: only the `translation` task path (`LLMClient`, `TranslationWorkUnitRunner`, `TaskEngine`). The `analysis` (glossary extraction) path has a similar blind-retry pattern but uses a different checkpoint-based retry mechanism and was left untouched to keep this change focused and low-risk.

## Test plan
- [x] `npx tsc -b --noEmit`
- [x] `npx vitest run` — full suite passes (pre-existing unrelated failures in `native-fs.test.ts` / `api-gateway-connections.test.ts` / `gui/preload/index.test.ts` are present on `main` too, unaffected by this change)
- [x] Added unit tests:
  - `LLMClient`: 401 → `request_error_retryable: false`; 429 → `true`; error with no status → `true` (conservative default)
  - `TranslationWorkUnitRunner`: permanent error marks item `status: "ERROR"` directly with a distinct log message; transient error still leaves `status: "NONE"` for the Engine to retry as before
  - `TaskEngine`: existing retry tests updated to inject `retryBackoffMs: () => 0` so they stay fast/deterministic; new backoff option defaults to the real delay in production